### PR TITLE
adding the test.router setting to testHealth task

### DIFF
--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -59,6 +59,7 @@ tasks.withType(ScalaCompile) {
 }
 
 task testHealth(type: Test) {
+    systemProperty 'test.router', 'true'
     include 'system/packages/**'
 }
 


### PR DESCRIPTION
adding the test.router setting to testHealth task. this allows us to use the proper IPs during the health tests