### PR TITLE
fix "database deleted after change errors" during health test

### DIFF
--- a/tests/src/test/scala/system/packages/CloudantHealthFeedTests.scala
+++ b/tests/src/test/scala/system/packages/CloudantHealthFeedTests.scala
@@ -127,7 +127,7 @@ class CloudantHealthFeedTests
                 }
 
                 println("Creating cloudant trigger feed.")
-                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName) {
+                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
                     (trigger, name) =>
                         trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
                             "username" -> myCloudantCreds.user.toJson,
@@ -138,58 +138,15 @@ class CloudantHealthFeedTests
                 }
                 feedCreationResult.stdout should include("ok")
 
+                // delete the whisk trigger, which will also delete the feed
+                wsk.trigger.delete(triggerName)
+
             } finally {
                 CloudantUtil.unsetUp(myCloudantCreds)
             }
     }
 
-    it should "only invoke as many times as specified" in withAssetCleaner(wskprops) {
-        (wp, assetHelper) =>
-            implicit val wskprops = wp // shadow global props and make implicit
-            val triggerName = s"dummyCloudantTrigger-${System.currentTimeMillis}"
-            val packageName = "dummyCloudantPackage"
-            val feed = "changes"
 
-            try {
-                CloudantUtil.setUp(myCloudantCreds)
-
-                val packageGetResult = wsk.pkg.get("/whisk.system/cloudant")
-                println("Fetching cloudant package.")
-                packageGetResult.stdout should include("ok")
-
-                println("Creating cloudant package binding.")
-                assetHelper.withCleaner(wsk.pkg, packageName) {
-                    (pkg, name) => pkg.bind("/whisk.system/cloudant", name)
-                }
-
-                println("Creating cloudant trigger feed.")
-                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
-                    (trigger, name) =>
-                        trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
-                            "username" -> myCloudantCreds.user.toJson,
-                            "password" -> myCloudantCreds.password.toJson,
-                            "host" -> myCloudantCreds.host().toJson,
-                            "dbname" -> myCloudantCreds.dbname.toJson,
-                            "maxTriggers" -> 1.toJson))
-                }
-                feedCreationResult.stdout should include("ok")
-
-                // Create 2 test docs in cloudant and assert that document was inserted successfully
-                println("Creating a test doc-1 in the cloudant")
-                val response1 = CloudantUtil.createDocument(myCloudantCreds, "{\"test\":\"test_doc_1\"}")
-                response1.get("ok").getAsString() should be("true")
-                println("Creating a test doc-2 in the cloudant")
-                val response2 = CloudantUtil.createDocument(myCloudantCreds, "{\"test\":\"test_doc_2\"}")
-                response2.get("ok").getAsString() should be("true")
-
-                println("Checking for activations")
-                val activations = wsk.activation.pollFor(N = 4, Some(triggerName)).length
-                println(s"Found activation size (should be exactly 1): $activations")
-                activations should be(1)
-            } finally {
-                CloudantUtil.unsetUp(myCloudantCreds)
-            }
-    }
 
     it should "not deny trigger creation when choosing maxTrigger count set to infinity (-1)" in withAssetCleaner(wskprops) {
 
@@ -213,7 +170,7 @@ class CloudantHealthFeedTests
                 }
 
                 println("Creating cloudant trigger feed.")
-                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName) {
+                val feedCreationResult = assetHelper.withCleaner(wsk.trigger, triggerName, confirmDelete = false) {
                 (trigger, name) =>
                     trigger.create(name, feed = Some(s"$packageName/$feed"), parameters = Map(
                         "username" -> myCloudantCreds.user.toJson,
@@ -224,6 +181,9 @@ class CloudantHealthFeedTests
                         expectedExitCode = 0)
                 }
                 feedCreationResult.stderr should not include("error")
+
+                // delete the whisk trigger, which will also delete the feed
+                wsk.trigger.delete(triggerName)
 
             } finally {
                 CloudantUtil.unsetUp(myCloudantCreds)


### PR DESCRIPTION
"database deleted after change errors" are thrown in the provider logs during the health test.  The reason is because the database (where changes are being listened on) is being deleted before the trigger feed is deleted.  Health tests should be positive tests to make sure provider is healthy with no errors thrown in log.  I am also moving the "too many fires" test (trigger fires more than max allowed) from health to the non health feeds test.   